### PR TITLE
Add CV page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ navigation:                # accepts {file, title, url, icon, sidebaricon}
   - {title: Research, url: "/research/"}
   - {title: SynBPS, url: "https://github.com/Mikeriess/SynBPS"}
   - {title: Hugging Face, url: "https://huggingface.co/mikeriess"}
-  - {title: CV, url: "https://www.linkedin.com/in/mike-riess-8ba5796b/"}
+  - {title: CV, url: "/cv/"}
   - {title: Scholar, url: "https://scholar.google.com/citations?user=Mgz-wTYAAAAJ"}
 
 external:                  # shows a footer with social links - for available icons see fontawesome.com/icons

--- a/cv.md
+++ b/cv.md
@@ -10,31 +10,53 @@ The most up-to-date version of my CV is always available on my [LinkedIn profile
 ## Experience
 
 ### Senior Research Scientist
-<p class="pub-meta">Telenor Research & Innovation, Telenor Group - Oslo, Norway</p>
+<p class="pub-meta">Telenor Research & Innovation, Telenor Group - Oslo, Norway - 2023-present</p>
 
-Research on business analytics and AI in the telecommunications sector, focusing on the evaluation of applied AI in business processes from three perspectives: process monitoring, process optimization, and process automation.
+Research on advanced analytics and AI in the telecommunications sector, focusing on the evaluation of applied AI in business processes: process monitoring, process optimization, and process automation.
 
-<!--
-Template for earlier positions - copy this block, fill it in, and remove the comment markers:
+### Senior Data Scientist / Data Scientist
+<p class="pub-meta">Telia - Oslo, Stockholm and Copenhagen - 2018-2023</p>
 
-### Job title
-<p class="pub-meta">Employer - Location - YYYY-YYYY</p>
+Machine Learning Center of Excellence (Telia Group) and Business Intelligence & Analytics (Telia Denmark); crowd insights (Division X, Sweden); analytics and insights, churn and CRM modelling (Telia Norway).
 
-One or two lines about the role.
--->
+### PhD Research Fellow
+<p class="pub-meta">NMBU - Norwegian University of Life Sciences - Ås, Norway - 2018-2022</p>
+
+Research on predictive and prescriptive process monitoring. Teaching in digital business transformation (INN350), machine learning for business process optimization (INN355), and applied machine learning (DAT200, DAT300). Supervision of master's theses within process automation and personalization.
+
+### Consultant / Research Assistant
+<p class="pub-meta">Epinion - Aarhus, Denmark - 2015-2018</p>
+
+Advanced analytics and reporting within aviation and transportation.
+
+### Research Assistant
+<p class="pub-meta">Department of Management, Aarhus BSS - Aarhus, Denmark - 2015-2017</p>
 
 ## Education
 
-### PhD in Economics and Business Administration
-<p class="pub-meta">Norwegian University of Life Sciences (NMBU) - defended 2023</p>
+### PhD in Business Analytics
+<p class="pub-meta">NMBU School of Economics and Business - 2018-2023</p>
 
-Specialized focus on predictive and prescriptive process monitoring. Thesis: [Essays on predictive and prescriptive process monitoring](/research/).
+Research on predictive and prescriptive process monitoring for decision support in operations. Thesis: [Essays on predictive and prescriptive process monitoring](/research/), defended June 2023.
 
-### MSc in Business Intelligence
-<p class="pub-meta">Aarhus University, Denmark</p>
+### MSc in Business Intelligence, Predictive Analytics
+<p class="pub-meta">Aarhus University, Denmark - 2015-2017</p>
 
-### BSc in Business Administration
-<p class="pub-meta">Aarhus University, Denmark</p>
+### BSc in Economics & Business Administration
+<p class="pub-meta">Aarhus University, Denmark - 2013-2015</p>
+
+### AP Degree in Marketing Management, International Marketing
+<p class="pub-meta">Business Academy Southwest, Denmark - 2011-2013</p>
+
+## Academic service
+
+- PhD Advisory Committee member, [NORA - The Norwegian Artificial Intelligence Research Consortium](https://www.nora.ai/) (2021-2023)
+- Reviewer, AAMAS 2025
+- Open-source committee member, Danish Data Science Community (2025)
+
+## Certifications
+
+- Deep Learning Specialization, Coursera / deeplearning.ai (2018)
 
 ## Publications
 

--- a/cv.md
+++ b/cv.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: "CV"
+permalink: "/cv/"
+description: "CV of Mike Riess - Senior Research Scientist at Telenor Research. Applied AI, business analytics and process mining."
+---
+
+The most up-to-date version of my CV is always available on my [LinkedIn profile](https://www.linkedin.com/in/mike-riess-8ba5796b/).
+
+## Experience
+
+### Senior Research Scientist
+<p class="pub-meta">Telenor Research & Innovation, Telenor Group - Oslo, Norway</p>
+
+Research on business analytics and AI in the telecommunications sector, focusing on the evaluation of applied AI in business processes from three perspectives: process monitoring, process optimization, and process automation.
+
+<!--
+Template for earlier positions - copy this block, fill it in, and remove the comment markers:
+
+### Job title
+<p class="pub-meta">Employer - Location - YYYY-YYYY</p>
+
+One or two lines about the role.
+-->
+
+## Education
+
+### PhD in Economics and Business Administration
+<p class="pub-meta">Norwegian University of Life Sciences (NMBU) - defended 2023</p>
+
+Specialized focus on predictive and prescriptive process monitoring. Thesis: [Essays on predictive and prescriptive process monitoring](/research/).
+
+### MSc in Business Intelligence
+<p class="pub-meta">Aarhus University, Denmark</p>
+
+### BSc in Business Administration
+<p class="pub-meta">Aarhus University, Denmark</p>
+
+## Publications
+
+See the [Research](/research/) page for a full list of papers with abstracts and links.
+
+## Profiles
+
+[LinkedIn](https://www.linkedin.com/in/mike-riess-8ba5796b/) - [Google Scholar](https://scholar.google.com/citations?user=Mgz-wTYAAAAJ) - [GitHub](https://github.com/Mikeriess) - [Hugging Face](https://huggingface.co/mikeriess)


### PR DESCRIPTION
## Summary

New `/cv/` page based on curated LinkedIn content, and the nav "CV" item now points at it instead of LinkedIn.

### Content (curated for the academic profile - quality over quantity)
- A LinkedIn reference at the top ("the most up-to-date version of my CV is always available on my LinkedIn profile"), per request
- **Experience**: Senior Research Scientist at Telenor Research & Innovation (2023-present); consolidated Telia data science roles across Oslo/Stockholm/Copenhagen (2018-2023); PhD Research Fellow at NMBU with teaching (INN350, INN355, DAT200, DAT300) and master's supervision (2018-2022); Epinion consultant/research assistant (2015-2018); research assistant at Dept. of Management, Aarhus BSS (2015-2017)
- **Education**: PhD in Business Analytics (NMBU, thesis linked), MSc Business Intelligence and BSc Economics & Business Administration (Aarhus University), AP Degree (Business Academy Southwest)
- **Academic service**: NORA PhD Advisory Committee (2021-2023), AAMAS 2025 reviewer, Danish Data Science Community open-source committee (2025)
- **Certifications**: Deep Learning Specialization (Coursera, 2018)
- **Publications**: pointer to `/research/`; **Profiles**: LinkedIn, Scholar, GitHub, Hugging Face

Intentionally left out as not relevant to an academic profile: early non-academic jobs (band management, DJ, marketing ventures, substitute teaching), military sergeant school, HHX, the five individual Coursera sub-courses, per-course university course lists, and grades.

### Verification
- `jekyll build` passes; CV nav item highlights as selected on `/cv/`; plain `-` separators throughout (verified zero `·`/`—`/`–` in rendered text)
- Screenshotted at 1280 px and 375 px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195znQDhLbXxY34S4mpGdCt