### PR TITLE
Rewrite the landing page for the updated site

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -293,6 +293,22 @@ main > article > header h1 a {
    Components
    ============================================================ */
 
+/* homepage portrait */
+.portrait {
+  float: right;
+  width: 150px;
+  height: auto;
+  border-radius: var(--radius);
+  margin: .25rem 0 1rem 1.5rem;
+}
+
+@media (max-width: 480px) {
+  .portrait {
+    width: 110px;
+    margin-left: 1rem;
+  }
+}
+
 /* publication list (research page) */
 .pub-meta {
   color: var(--muted);

--- a/index.md
+++ b/index.md
@@ -1,16 +1,11 @@
 ---
 layout: page
 title:  "Mike Riess"
---- 
-I am a Senior Research Scientist at Telenor Research, specializing in Business Analytics and AI within the telecommunications sector. 
+---
+<img src="/Mike.png" alt="Mike Riess" class="portrait">
 
-My research concentrates on the evaluation of applied AI in business processes from three key perspectives: process monitoring, process optimization, and process automation.
+I am a Senior Research Scientist at Telenor Research in Oslo, working on applied AI and business analytics in the telecommunications sector.
 
-I hold a PhD in Economics and Business Administration with a specialized focus on predictive and prescriptive process monitoring from the Norwegian University of Life Sciences (NMBU). Additionally, I obtained my MSc in Business Intelligence and BSc in Business Administration from Aarhus University, Denmark.
+My research spans two threads: the evaluation of applied AI in business processes - process monitoring, optimization, and automation - and, more recently, large language models and NLP for customer service in the Nordic languages.
 
-For further details, please refer to my [LinkedIn profile](https://www.linkedin.com/in/mike-riess-8ba5796b/).
-
-Best,<br>
-Mike
-
-![Mike](Mike.png)
+I hold a PhD in Business Analytics from the Norwegian University of Life Sciences (NMBU). See my [research](/research/) for publications, or my [CV](/cv/) for the full background.


### PR DESCRIPTION
## Summary

The landing page text predated the research and CV pages. This PR replaces it with three short paragraphs and a repositioned portrait.

### Changes
- **Paragraph 1**: current role (Senior Research Scientist, Telenor Research, Oslo)
- **Paragraph 2**: research threads - applied AI in business processes (monitoring, optimization, automation) plus the recent LLM/NLP work for Nordic-language customer service, so the description matches the newest publications
- **Paragraph 3**: one-line education summary with internal pointers to `/research/` and `/cv/` (previously the page duplicated the full education history and pointed to LinkedIn for details)
- Removed the email-style "Best, Mike" sign-off
- The portrait now floats top-right at 150 px with rounded corners (110 px on small screens) instead of rendering as a raw full-width image below the sign-off

### Verification
- `jekyll build` passes; screenshotted `/` at 1280 px and 375 px - photo floats correctly, text wraps cleanly, internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195znQDhLbXxY34S4mpGdCt

---
_Generated by [Claude Code](https://claude.ai/code/session_0195znQDhLbXxY34S4mpGdCt)_